### PR TITLE
problemMatcher tsc -> mscompile

### DIFF
--- a/docs/how-to/develop-vscode/README.md
+++ b/docs/how-to/develop-vscode/README.md
@@ -47,7 +47,7 @@ Inside `tasks.json` add the following content. Edit the csproj's name if yours i
                 "build",
                 "${workspaceFolder}/MyGame.csproj"
             ],
-            "problemMatcher": "$tsc"
+            "problemMatcher": "$msCompile"
         }
     ]
 }


### PR DESCRIPTION
I came across the live site while googling something else, and I believe this task configuration is wrong? `$tsc` is the typescript problemmatcher, i believe this is supposed to be `$msCompile`